### PR TITLE
Task.7-1 記事に関するAPIのルーティングの実装【Article に関する API 実装】

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,4 +3,5 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+  validates :title,  presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,5 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+  validates :name, presence: true
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name { Faker::Name.name }
-    password { Faker::Internet.password }
-    email { Faker::Internet.email }
+    name { Faker::Lorem.characters(number: Random.new.rand(1..30)) }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+
+  context "必要な情報が揃っている場合" do
+    let(:user) { build(:user) }
+
+    it "ユーザー登録できる" do
+      expect(user).to be_valid
+    end
+  end
+
+
+
+  context "名前のみ入力している場合" do
+    let(:user) { build(:user, email: nil, password: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "email がない場合" do
+    let(:user) { build(:user, email: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "password がない場合" do
+    let(:user) { build(:user, password: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,9 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    config.define_derived_metadata do |meta|
+      meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
+    end
   end
 
   # rspec-mocks config goes here. You can use an alternate test double


### PR DESCRIPTION
# 概要
- Task.7-1 記事に関するAPIのルーティングの実装【Article に関する API 実装】
- article.rbに自分で作成を行い、できた感じはあったが実際はmodelにも必要だった。（回答を確認）